### PR TITLE
Adjust maxDuration for Vercel functions to 60 seconds

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/**": {
+      "maxDuration": 60
+    }
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,5 @@
 {
   "functions": {
-    "api/**": {
-      "maxDuration": 60
-    }
+    "maxDuration": 60
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "functions": {
-    "**/**": {
+    "api/custom_generate/**": {
       "maxDuration": 60
     }
   }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,7 @@
 {
   "functions": {
-    "maxDuration": 60
+    "**/**": {
+      "maxDuration": 60
+    }
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "functions": {
-    "api/custom_generate/**": {
+    "app/api/custom_generate/**": {
       "maxDuration": 60
     }
   }


### PR DESCRIPTION
Related to #1

Adds a new `vercel.json` file to the repository to configure the maxDuration for Vercel functions to 60 seconds.

- Adds `vercel.json` at the root of the repository with a configuration that sets the `maxDuration` for functions under the `api/**` path to 60 seconds, aligning with the project's need to increase function execution time to 1 minute.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jonico/suno-api-vercel/issues/1?shareId=6b61f9af-0f6f-4312-b435-bc45a5e6a84c).